### PR TITLE
[Client] 모달 컴포넌트 타이틀영역 버튼 다양화

### DIFF
--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -1,28 +1,29 @@
 /*
 담당 : 이수련
 생성 : 2022.11.15
-수정 : -
+수정 : 2022.11.16
 소개 : 모달 창 컴포넌트
 설명 : 
   - 페이지에서 공통적으로 사용되는 모달 창 컴포넌트입니다.
   - 사용예시:
-    //배경 블러처리 있을 때 (title optional)
-    <Modal title="제목" bg={true} isOn={isPopup} setIsOn={setIsPopup}>
-      <p>내용</p>
-    </Modal>
-
-    //배경 블러처리 없을 때 (title required)
-    <Modal title="제목" bg={false} isOn={isPopup} setIsOn={setIsPopup}>
-      <p>내용</p>
-    </Modal>
-
-  - 옵션: 옵션에 대한 설명은 wiki를 참고해주세요
-  - 주의 사항: bg가 false 일땐, 반드시 title이 존재해야합니다.
+    <Modal
+        title="제목" //제목영역에 띄울 글자
+        maxWidth="700px" //L사이즈에서 최대 너비
+        bg={true} //배경 까만색 될건지
+        isOn={isPopup} //팝업 끄고 키는 state
+        setIsOn={setIsPopup} //팝업 끄고 키는 set함수
+        onTitleBtnClick={onClick} //타이틀 영역 버튼 누르면 실행되는 함수
+        titleBtn="close" //타이틀 영역 어떤 버튼이 필요한지
+      >
+  - 
 */
 
 import React from "react";
 import { Bg, Popup, PopupHeader } from "./style";
 import { ReactComponent as CloseBtn } from "../../assets/img/close-icon.svg";
+import { ReactComponent as NextBtn } from "../../assets/img/arrow-icon.svg";
+import { ReactComponent as DoneBtn } from "../../assets/img/check-icon.svg";
+import { ReactComponent as MoreBtn } from "../../assets/img/more-icon.svg";
 
 interface Prop {
   children: React.ReactNode;
@@ -32,9 +33,21 @@ interface Prop {
   title?: string;
   isOn: boolean;
   setIsOn: (arg: boolean) => void;
+  titleBtn?: "close" | "next" | "done" | "more" | "none";
+  onTitleBtnClick?: () => void;
 }
 
-const Modal = ({ children, className, maxWidth = "640px", bg = false, title = "", isOn = false, setIsOn }: Prop) => {
+const Modal = ({
+  children,
+  className,
+  maxWidth = "640px",
+  bg = false,
+  title = "",
+  isOn = false,
+  setIsOn,
+  titleBtn = "none",
+  onTitleBtnClick,
+}: Prop) => {
   const HandleOnOff = () => {
     setIsOn(!isOn);
   };
@@ -46,7 +59,15 @@ const Modal = ({ children, className, maxWidth = "640px", bg = false, title = ""
         {title ? (
           <PopupHeader title={title}>
             {title}
-            {!bg ? <CloseBtn onClick={HandleOnOff} /> : ""}
+            {
+              {
+                close: <CloseBtn onClick={HandleOnOff} />,
+                next: <NextBtn className="orange" onClick={onTitleBtnClick} />,
+                done: <DoneBtn className="orange" onClick={onTitleBtnClick} />,
+                more: <MoreBtn onClick={onTitleBtnClick} />,
+                none: "",
+              }[titleBtn]
+            }
           </PopupHeader>
         ) : (
           ""

--- a/client/src/components/Modal/style.ts
+++ b/client/src/components/Modal/style.ts
@@ -94,5 +94,17 @@ export const PopupHeader = styled.div<PopupHeaderProp>`
         fill: var(--color-light-black);
       }
     }
+
+    &.orange {
+      path {
+        fill: var(--color-orange);
+      }
+
+      &:hover {
+        path {
+          filter: brightness(1.5);
+        }
+      }
+    }
   }
 `;


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요>?
- [x] 개인 문서 작성을 하셨나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #15


## 무엇이 추가 되었나요?
기존에 모달 창 타이틀 영역 오른쪽에 나타나는 버튼 close 버튼만 대응이 되었는데,
`titleBtn`과`onTitleBtnClick` prop을 추가하면서
`"close" | "next" | "done" | "more" | "none" ` 로 다양한 아이콘으로 버튼을 만들 수 있도록 하였습니다.


## 기타 정보
